### PR TITLE
Fix requirements list for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
     author_email='circuitpython@adafruit.com',
 
     install_requires=[
-        'Adafruit-Blinka'
-        'adafruit-circuitpython-busdevice'
-        'adafruit-circuitpython-register'
+        'Adafruit-Blinka',
+        'adafruit-circuitpython-busdevice',
+        'adafruit-circuitpython-register',
     ],
 
     # Choose your license


### PR DESCRIPTION
Commas? Hopefully that's all it is.

currently:
```console
pi@raspberrypi:~ $ pip3 install --no-cache-dir adafruit-circuitpython-mcp9600
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting adafruit-circuitpython-mcp9600
  Downloading https://www.piwheels.org/simple/adafruit-circuitpython-mcp9600/adafruit_circuitpython_mcp9600-1.0.1-py3-none-any.whl
Collecting Adafruit-Blinkaadafruit-circuitpython-busdeviceadafruit-circuitpython-register (from adafruit-circuitpython-mcp9600)
  Could not find a version that satisfies the requirement Adafruit-Blinkaadafruit-circuitpython-busdeviceadafruit-circuitpython-register (from adafruit-circuitpython-mcp9600) (from versions: )
No matching distribution found for Adafruit-Blinkaadafruit-circuitpython-busdeviceadafruit-circuitpython-register (from adafruit-circuitpython-mcp9600)
```