### PR TITLE
Add support for MCP9601

### DIFF
--- a/adafruit_mcp9600.py
+++ b/adafruit_mcp9600.py
@@ -218,8 +218,8 @@ class MCP9600:
         self.buf[1] = tcfilter | (ttype << 4)
         with self.i2c_device as tci2c:
             tci2c.write(self.buf, end=2)
-        if self._device_id != 0x40:
-            raise RuntimeError("Failed to find MCP9600 - check wiring!")
+        if self._device_id not in (0x40, 0x41):
+            raise RuntimeError("Failed to find MCP9600 or MCP9601 - check wiring!")
 
     def alert_config(
         self,


### PR DESCRIPTION
Device ID is different on MCP9601 - this adds the 9601 device ID to the check. Otherwise, code works as expected. Tested with simpletest, and also tested alert functionality. 