### PR TITLE
Do not let I2CDevice probe for the device

### DIFF
--- a/adafruit_mcp9600.py
+++ b/adafruit_mcp9600.py
@@ -217,7 +217,10 @@ class MCP9600:
         tcfilter: int = 0,
     ) -> None:
         self.buf = bytearray(3)
-        self.i2c_device = I2CDevice(i2c, address)
+        # Do not probe for the device with a zero-length write.
+        # The MCP960x does not like zero-length writes and will usually NAK,
+        # unless the write is rapidly repeated.
+        self.i2c_device = I2CDevice(i2c, address, probe=False)
         self.type = tctype
         # is this a valid thermocouple type?
         if tctype not in MCP9600.types:


### PR DESCRIPTION
The MCP960x does not seem to like zero-length writes, and can NAK when probed with such a write. On `atmel-samd`, the write was repeated once immediately if it failed, and for some reason this worked. But on other ports, the write is done just once, and it fails. If the write is repeated a little later, it still fails.

So when creating the `adafruit_busdevice.I2CDevice()`, ask it not to probe.