### PR TITLE
Update delta temp doc and remove comment.

### DIFF
--- a/adafruit_mcp9600.py
+++ b/adafruit_mcp9600.py
@@ -363,7 +363,10 @@ class MCP9600:
 
     @property
     def delta_temperature(self) -> float:
-        """Delta temperature in Celsius"""
+        """
+        Delta between hot junction (thermocouple probe) and
+        cold junction (ambient/room) temperatures in Celsius
+        """
         data = self._read_register(_REGISTER_DELTA_TEMP, 2)
         value = unpack(">xH", data)[0] * 0.0625
         if data[1] & 0x80:

--- a/examples/mcp9600_simpletest.py
+++ b/examples/mcp9600_simpletest.py
@@ -6,8 +6,6 @@ import board
 import busio
 import adafruit_mcp9600
 
-# frequency must be set for the MCP9600 to function.
-# If you experience I/O errors, try changing the frequency.
 i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
 mcp = adafruit_mcp9600.MCP9600(i2c)
 


### PR DESCRIPTION
Frequency comments in simpletest were vague and, after testing, unnecessary. Removing.

During testing, determined delta temperature documentation to be lacking. Updated here to be clearer, will update in guide as well.