### PR TITLE
set_ambient_resolution

### DIFF
--- a/adafruit_mcp9600.py
+++ b/adafruit_mcp9600.py
@@ -381,12 +381,13 @@ class MCP9600:
 
     def set_ambient_resolution(self, resolution):
         """
-        Sets the ambient (cold-junction) temperature sensor resolution.
         :param resolution: Either AMBIENT_RESOLUTION_0_0625 (0.0625°C)
-                           or AMBIENT_RESOLUTION_0_25 (0.25°C).
+                            or AMBIENT_RESOLUTION_0_25 (0.25°C).
         """
-        if resolution not in [self.AMBIENT_RESOLUTION_0_0625, self.AMBIENT_RESOLUTION_0_25]:
-            raise ValueError("Resolution must be AMBIENT_RESOLUTION_0_0625 or AMBIENT_RESOLUTION_0_25")
-        
-        # Set the register bit based on the resolution
-        self.ambient_resolution = resolution
+        if resolution not in [
+            self.AMBIENT_RESOLUTION_0_0625,
+            self.AMBIENT_RESOLUTION_0_25,
+        ]:
+            raise ValueError(
+                "Resolution must be AMBIENT_RESOLUTION_0_0625 or AMBIENT_RESOLUTION_0_25"
+            )

--- a/adafruit_mcp9600.py
+++ b/adafruit_mcp9600.py
@@ -378,3 +378,15 @@ class MCP9600:
         with self.i2c_device as i2c:
             i2c.write_then_readinto(self.buf, self.buf, out_end=count, in_start=1)
         return self.buf
+
+    def set_ambient_resolution(self, resolution):
+        """
+        Sets the ambient (cold-junction) temperature sensor resolution.
+        :param resolution: Either AMBIENT_RESOLUTION_0_0625 (0.0625°C)
+                           or AMBIENT_RESOLUTION_0_25 (0.25°C).
+        """
+        if resolution not in [self.AMBIENT_RESOLUTION_0_0625, self.AMBIENT_RESOLUTION_0_25]:
+            raise ValueError("Resolution must be AMBIENT_RESOLUTION_0_0625 or AMBIENT_RESOLUTION_0_25")
+        
+        # Set the register bit based on the resolution
+        self.ambient_resolution = resolution


### PR DESCRIPTION
settable between either 0.0625 or 0.25. Had been hard coded.

Tested on RP2040 with CircuitPython 9.1.4 and MCP9600. Works set or unset. Small change designed to match Arduino set ambient cold-joint resolution behavior.

example code to set high resolution:

```
# Update mcp9600_simpletest.py

import time
import board
import busio
import adafruit_mcp9600

i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
mcp = adafruit_mcp9600.MCP9600(i2c)

# Set ambient resolution to 0.0625°C using the predefined constant
mcp.set_ambient_resolution(mcp.AMBIENT_RESOLUTION_0_0625)

while True:
    print((mcp.ambient_temperature, mcp.temperature, mcp.delta_temperature))
    time.sleep(1)
```